### PR TITLE
細かな微調整

### DIFF
--- a/lib/pages/map/photo_preview_page.dart
+++ b/lib/pages/map/photo_preview_page.dart
@@ -84,7 +84,8 @@ class _PhotoPreviewPageState extends State<PhotoPreviewPage> {
                       : null,
                   icon: const Icon(Icons.arrow_forward),
                   label: const Text("次"))),
-        ])
+        ]),
+        Row(children: const [SizedBox(height: 30, child: null)]),
       ])),
     );
   }

--- a/lib/pages/map/photo_preview_page.dart
+++ b/lib/pages/map/photo_preview_page.dart
@@ -38,28 +38,42 @@ class _PhotoPreviewPageState extends State<PhotoPreviewPage> {
       body: Container(
           child: Column(children: [
         Expanded(
-            child: FutureBuilder<String>(
-          future:
-              _imageLoader.getDownloadUrl(widget.map, widget.photos[_index]),
-          builder: (context, snapshot) {
-            if (snapshot.connectionState != ConnectionState.done) {
-              return const Center(child: CircularProgressIndicator());
-            }
-            if (snapshot.hasError) {
-              return const Center(child: Text("画像のロードに失敗しました"));
-            }
-            if (!snapshot.hasData) {
-              return const Center(child: Text("画像が見つかりません"));
-            }
-            return PhotoView(
-              imageProvider: NetworkImage(snapshot.data!),
-              minScale: PhotoViewComputedScale.contained * 0.8,
-              initialScale: PhotoViewComputedScale.contained,
-              basePosition: Alignment.center,
-              backgroundDecoration: const BoxDecoration(color: Colors.black),
-            );
-          },
-        )),
+            child: GestureDetector(
+                onHorizontalDragEnd: (details) => {
+                      if (details.primaryVelocity! > 0)
+                        {
+                          if (_index > 0) {setState(() => _index--)}
+                        }
+                      else if (details.primaryVelocity! < 0)
+                        {
+                          if (_index < _photoCount - 1)
+                            {setState(() => _index++)}
+                        }
+                    },
+                onVerticalDragEnd: (details) => {Navigator.of(context).pop()},
+                child: FutureBuilder<String>(
+                  future: _imageLoader.getDownloadUrl(
+                      widget.map, widget.photos[_index]),
+                  builder: (context, snapshot) {
+                    if (snapshot.connectionState != ConnectionState.done) {
+                      return const Center(child: CircularProgressIndicator());
+                    }
+                    if (snapshot.hasError) {
+                      return const Center(child: Text("画像のロードに失敗しました"));
+                    }
+                    if (!snapshot.hasData) {
+                      return const Center(child: Text("画像が見つかりません"));
+                    }
+                    return PhotoView(
+                      imageProvider: NetworkImage(snapshot.data!),
+                      minScale: PhotoViewComputedScale.contained * 0.8,
+                      initialScale: PhotoViewComputedScale.contained,
+                      basePosition: Alignment.center,
+                      backgroundDecoration:
+                          const BoxDecoration(color: Colors.black),
+                    );
+                  },
+                ))),
         // Text()
         Row(children: [
           Expanded(

--- a/lib/pages/map/point_add_form.dart
+++ b/lib/pages/map/point_add_form.dart
@@ -94,6 +94,7 @@ class _PointAddFormState extends State<PointAddForm> {
                     child: Text('キャンセル')),
               ],
             ),
+            Row(children: const [SizedBox(height: 30, child: null)]),
             Padding(
                 padding: EdgeInsets.only(
                     bottom: MediaQuery.of(context).viewInsets.bottom)),

--- a/lib/pages/map/point_edit_form.dart
+++ b/lib/pages/map/point_edit_form.dart
@@ -96,6 +96,7 @@ class _PointEditFormState extends State<PointEditForm> {
                     child: Text('キャンセル')),
               ],
             ),
+            Row(children: const [SizedBox(height: 30, child: null)]),
             Padding(
                 padding: EdgeInsets.only(
                     bottom: MediaQuery.of(context).viewInsets.bottom)),

--- a/lib/pages/map/point_info_form.dart
+++ b/lib/pages/map/point_info_form.dart
@@ -55,13 +55,14 @@ class PointInfoForm extends StatelessWidget {
                         ], child: PointEditForm(store.mapInfo!, _spotId));
                       });
                 },
-                child: Text('編集')),
+                child: const Text('編集')),
             TextButton(
                 onPressed: () {
                   Navigator.pop(context);
                 },
-                child: Text('閉じる'))
+                child: const Text('閉じる'))
           ]),
+          Row(children: const [SizedBox(height: 30, child: null)]),
         ],
       ),
     );


### PR DESCRIPTION
## やったこと
- iPhone13用に画面下部に隙間を追加
    - `SafeArea` を使うのが正しいのでこの部分は後で要修正
- 写真プレビュー時、上下左右のフリックに応じて写真の切り替えや画面を閉じる対応
