### PR TITLE
登録・更新中にボタンを「保存中」と表示する

### DIFF
--- a/lib/pages/map/point_add_form.dart
+++ b/lib/pages/map/point_add_form.dart
@@ -23,18 +23,18 @@ class _PointAddFormState extends State<PointAddForm> {
   final TextEditingController _commentController = TextEditingController();
   final MapInfo _mapInfo;
   final Position _position;
-  PointAddFormStore? _state;
+  PointAddFormStore? _store;
 
   _PointAddFormState(this._mapInfo, this._position);
 
   @override
   Widget build(BuildContext context) {
-    if (_state == null) {
-      _state = Provider.of<PointAddFormStore>(context);
+    if (_store == null) {
+      _store = Provider.of<PointAddFormStore>(context);
       _titleController
-          .addListener(() => _state!.setTitle(_titleController.text));
+          .addListener(() => _store!.setTitle(_titleController.text));
       _commentController
-          .addListener(() => _state!.setComment(_commentController.text));
+          .addListener(() => _store!.setComment(_commentController.text));
     }
 
     return Padding(
@@ -74,7 +74,7 @@ class _PointAddFormState extends State<PointAddForm> {
                   IconButton(
                     icon: Icon(Icons.photo),
                     onPressed: () {
-                      _state!.pickImage();
+                      _store!.pickImage();
                     },
                   ),
                   _createImagePreview()
@@ -85,7 +85,7 @@ class _PointAddFormState extends State<PointAddForm> {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 TextButton(
-                    onPressed: _state!.isValidInput() ? _saveForm : null,
+                    onPressed: _store!.isValidInput() ? _saveForm : null,
                     child: Text('登録')),
                 TextButton(
                     onPressed: () {
@@ -103,16 +103,16 @@ class _PointAddFormState extends State<PointAddForm> {
   }
 
   Future<void> _saveForm() async {
-    await _state!.save(_mapInfo, _position);
+    await _store!.save(_mapInfo, _position);
     Navigator.pop(context);
   }
 
   Widget _createImagePreview() {
-    if (_state!.photos.isEmpty) {
+    if (_store!.photos.isEmpty) {
       return Container(child: Expanded(child: Text('写真を選択')));
     }
 
-    List<Image> imageList = _state!.photos.map((XFile file) {
+    List<Image> imageList = _store!.photos.map((XFile file) {
       return Image.file(File(file.path), height: 50);
     }).toList();
 

--- a/lib/pages/map/point_add_form.dart
+++ b/lib/pages/map/point_add_form.dart
@@ -58,7 +58,7 @@ class _PointAddFormState extends State<PointAddForm> {
               padding: const EdgeInsets.only(bottom: 10),
               child: Row(
                 children: [
-                  Text('コメント'),
+                  const Text('コメント'),
                   Expanded(
                       child: TextField(
                     controller: _commentController,
@@ -70,9 +70,9 @@ class _PointAddFormState extends State<PointAddForm> {
               padding: const EdgeInsets.only(bottom: 10),
               child: Row(
                 children: [
-                  Text('写真'),
+                  const Text('写真'),
                   IconButton(
-                    icon: Icon(Icons.photo),
+                    icon: const Icon(Icons.photo),
                     onPressed: () {
                       _store!.pickImage();
                     },
@@ -85,13 +85,13 @@ class _PointAddFormState extends State<PointAddForm> {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 TextButton(
-                    onPressed: _store!.isValidInput() ? _saveForm : null,
-                    child: Text('登録')),
+                    onPressed: _store!.canSave() ? _saveForm : null,
+                    child: Text(_store?.saving == true ? '保存中...' : '登録')),
                 TextButton(
                     onPressed: () {
                       Navigator.pop(context);
                     },
-                    child: Text('キャンセル')),
+                    child: const Text('キャンセル')),
               ],
             ),
             Row(children: const [SizedBox(height: 30, child: null)]),
@@ -109,7 +109,7 @@ class _PointAddFormState extends State<PointAddForm> {
 
   Widget _createImagePreview() {
     if (_store!.photos.isEmpty) {
-      return Container(child: Expanded(child: Text('写真を選択')));
+      return Container(child: const Expanded(child: Text('写真を選択')));
     }
 
     List<Image> imageList = _store!.photos.map((XFile file) {

--- a/lib/pages/map/point_add_form_store.dart
+++ b/lib/pages/map/point_add_form_store.dart
@@ -15,9 +15,12 @@ class PointAddFormStore extends ChangeNotifier {
 
   List<XFile> _photos = [];
 
+  bool _saving = false;
+
   String get title => _title;
   String get comment => _comment;
   List<XFile> get photos => _photos;
+  bool get saving => _saving;
 
   PointAddFormStore(this._mapInfoRepository) : _picker = ImagePicker();
 
@@ -33,6 +36,10 @@ class PointAddFormStore extends ChangeNotifier {
 
   Future<void> save(MapInfo mapInfo, Position _position) async {
     var spot = Spot(_title, _position, comment: _comment);
+
+    _saving = true;
+    notifyListeners();
+
     var uploadedPhotos =
         await _mapInfoRepository.uploadPhotos(mapInfo, _photos);
 
@@ -44,11 +51,17 @@ class PointAddFormStore extends ChangeNotifier {
     _title = '';
     _comment = '';
     _photos = [];
+    _saving = false;
+
     notifyListeners();
   }
 
   bool isValidInput() {
     return _title.length > 0;
+  }
+
+  bool canSave() {
+    return isValidInput() && !_saving;
   }
 
   Future<void> pickImage() async {

--- a/lib/pages/map/point_edit_form.dart
+++ b/lib/pages/map/point_edit_form.dart
@@ -87,8 +87,8 @@ class _PointEditFormState extends State<PointEditForm> {
               mainAxisAlignment: MainAxisAlignment.spaceEvenly,
               children: [
                 TextButton(
-                    onPressed: _store!.isValidInput() ? _saveForm : null,
-                    child: Text('更新')),
+                    onPressed: _store!.canSave() ? _saveForm : null,
+                    child: Text(_store!.saving == true ? '保存中...' : '更新')),
                 TextButton(
                     onPressed: () {
                       Navigator.pop(context);

--- a/lib/pages/map/point_edit_form.dart
+++ b/lib/pages/map/point_edit_form.dart
@@ -48,7 +48,7 @@ class _PointEditFormState extends State<PointEditForm> {
               padding: const EdgeInsets.only(bottom: 10),
               child: Row(
                 children: [
-                  Text('タイトル'),
+                  const Text('タイトル'),
                   Expanded(
                       child: TextField(
                     controller: _titleController,
@@ -60,7 +60,7 @@ class _PointEditFormState extends State<PointEditForm> {
               padding: const EdgeInsets.only(bottom: 10),
               child: Row(
                 children: [
-                  Text('コメント'),
+                  const Text('コメント'),
                   Expanded(
                       child: TextField(
                     controller: _commentController,
@@ -72,9 +72,9 @@ class _PointEditFormState extends State<PointEditForm> {
               padding: const EdgeInsets.only(bottom: 10),
               child: Row(
                 children: [
-                  Text('写真'),
+                  const Text('写真'),
                   IconButton(
-                    icon: Icon(Icons.photo),
+                    icon: const Icon(Icons.photo),
                     onPressed: () {
                       _store!.pickImage();
                     },
@@ -93,7 +93,7 @@ class _PointEditFormState extends State<PointEditForm> {
                     onPressed: () {
                       Navigator.pop(context);
                     },
-                    child: Text('キャンセル')),
+                    child: const Text('キャンセル')),
               ],
             ),
             Row(children: const [SizedBox(height: 30, child: null)]),
@@ -111,7 +111,7 @@ class _PointEditFormState extends State<PointEditForm> {
 
   Widget _createImagePreview() {
     if (_store!.photos.isEmpty) {
-      return Container(child: Expanded(child: Text('写真を選択')));
+      return Container(child: const Expanded(child: Text('写真を選択')));
     }
 
     List<Image> imageList = _store!.photos.map((XFile file) {

--- a/lib/pages/map/point_edit_form_store.dart
+++ b/lib/pages/map/point_edit_form_store.dart
@@ -19,9 +19,12 @@ class PointEditFormStore extends ChangeNotifier {
 
   List<XFile> _photos = [];
 
+  bool _saving = false;
+
   String get title => _title;
   String get comment => _comment;
   List<XFile> get photos => _photos;
+  bool get saving => _saving;
 
   PointEditFormStore(this._mapInfoRepository) : _picker = ImagePicker();
 
@@ -50,6 +53,10 @@ class PointEditFormStore extends ChangeNotifier {
     var photos = _mapInfo.spots[_spotId]!.photos;
     var newMapPoint = Spot(_title, point,
         comment: _comment, newDate: _mapInfo.spots[_spotId]!.date);
+
+    _saving = true;
+    notifyListeners();
+
     var uploadedPhotos =
         await _mapInfoRepository.uploadPhotos(_mapInfo, _photos);
 
@@ -62,11 +69,16 @@ class PointEditFormStore extends ChangeNotifier {
     _title = '';
     _comment = '';
     _photos = [];
+    _saving = false;
     notifyListeners();
   }
 
   bool isValidInput() {
     return _title.length > 0;
+  }
+
+  bool canSave() {
+    return isValidInput() && !_saving;
   }
 
   Future<void> pickImage() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 1.3.1
+version: 1.3.2
 
 environment:
   sdk: ">=2.16.1 <3.0.0"


### PR DESCRIPTION
## チケット
- #11

## やったこと
- 登録・更新中はボタンを「保存中...」と表示する

## UI before / after
![image](https://user-images.githubusercontent.com/3823428/167234157-3934ee95-0147-4028-b3c4-468c5cad1ad0.png)


## 補足
